### PR TITLE
Added base64 image display on the htmlTable view

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/HtmlWidgets.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/HtmlWidgets.java
@@ -11,6 +11,7 @@ import com.cohort.util.MustBe;
 import com.cohort.util.String2;
 import com.cohort.util.Test;
 import com.cohort.util.XML;
+import gov.noaa.pfel.erddap.util.EDStatic;
 
 import gov.noaa.pfel.coastwatch.pointdata.Table;
 import gov.noaa.pfel.coastwatch.util.SSR;
@@ -355,6 +356,26 @@ public class HtmlWidgets {
             tooltipHtml +
             "</span></span>";
     }
+    /**
+     * This generates the HTML to add a cssTooltip to the specified item. Modified for base64 images
+     *
+     * @param itemHtml  The html for the thing (e.g., "?"-image) that is always visible
+     * @param spanOther other parameters (e.g., style) for the inner span
+     * @param tooltipHtml
+     * @param buttonHTML
+     * @return the HTML to add a cssTooltip to the specified item.
+     */
+    public static String cssTooltipBase64(String itemHtml, String spanOther, String tooltipHtml, String buttonHTML) {
+        return 
+            "<span class=\"cssTooltip\">" +
+            itemHtml +
+            "<span class=\"cssTooltipInner\"" + 
+                (spanOther.length() == 0? "" : " " + spanOther) +
+                ">" +
+            tooltipHtml +
+            "</span></span>"+
+            "<span class=\"cssTooltip\">" + buttonHTML+ "</span>";                        
+    }
 
 
     /** 
@@ -448,6 +469,60 @@ public class HtmlWidgets {
 
             "</span></span>"; */
 
+    }
+
+    /** 
+     * This creates the html for an base64 encoded image ('?') with a cssTooltip with a 
+     * deferred-load second image.
+     * This is based on CSS-only image tooltip at 
+     *   https://codepen.io/electricalbah/pen/eJRLVd (URL works in browser but not in link tests)
+     *
+     * @param img1Url for the image for the user to hover over, e.g., questionMarkImageUrl.
+     *   It must be in the images directory.
+     * @param img1Alt alt text for the imgUrl, e.g., "?". It will be encoded as HTML attribute.
+     * @param img1Other additional parameter=values for img1. It should end with a space.
+     * @param img2Url
+     * @param img2ID  a unique (for the document) id, e.g., img1. 
+     *   Just simple chars -- it isn't further encoded.
+     * @param language the index of the selected language
+     * @return the html for an image ('?') with a cssTooltip with a deferred-load second image.
+     */
+    public static String cssTooltipImageBase64(String img1Url, String img1Alt, String img1Other,
+        String img2Url, String img2ID,int language) {
+
+        String img1UrlEncoded = XML.encodeAsHTMLAttribute(img1Url);
+        String loadingUrl = File2.getDirectory(img1Url) + "loading.png";
+        String loadingUrlEncoded = XML.encodeAsHTMLAttribute(loadingUrl);
+        return 
+
+            //the original: a popup, no bigger than 90% of screen width
+            //In Chrome, a big image is shrunk to 90%. In Firefox, big image is cropped.
+            cssTooltipBase64(
+            "<img " + img1Other + " src=\"" + img1UrlEncoded + 
+                "\" alt=\"" + XML.encodeAsHTMLAttribute(img1Alt) + "\"\n" +
+                "  onmouseover=\"var el=document.getElementById('" + img2ID + "'); el.setAttribute('src',el.getAttribute('data-src'));\"/>",    
+
+            "style=\"padding:0px; max-width:90%;\"",  
+
+            "<img style=\"max-width:100%;\" " +
+                "id=\"" + img2ID + "\" class=\"B\" src=\"" + loadingUrlEncoded + "\"\n" + //vertical-align: 'b'ottom
+                "  data-src=\"" + img2Url + 
+                "\" alt=\"data:image/png;base64\">",
+
+                "&nbsp;data:image/png;base64&nbsp;<a href=\"#\" onclick=\"javascript:if(navigator.clipboard==undefined){alert('copy to clipboardd not available');return false};navigator.clipboard.writeText('" + img2Url +"');\" style=\"cursor: pointer; cursor: hand;\" >["+ EDStatic.copytexttoclipboardAr[language] + "]</a> " +                
+                "&nbsp;<a href=\"#\" onclick=\"javascript:if(navigator.clipboard==undefined){alert('copy to clipboardd not available');return false};"+
+                " var img = new Image();"+
+                " img.onload = () => {"+
+                " const c = document.createElement('canvas');"+
+                " const ctx = c.getContext('2d');"+
+                " c.width = img.naturalWidth;"+
+                " c.height = img.naturalHeight;"+
+                " ctx.drawImage(img, 0, 0);"+
+                " const blob=c.toBlob((blob) => {const item = new ClipboardItem({ 'image/png': blob });navigator.clipboard.write([item]);},'image/png',0.75);};"+
+                " img.src = '" + img2Url + "';"+
+                " return false;\""+                 
+                " style=\"cursor: pointer; cursor: hand;\" >["+ EDStatic.copyimagetoclipboardAr[language] + "]</a>"                    
+            );
     }
 
     /** 

--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/HtmlWidgets.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/HtmlWidgets.java
@@ -509,8 +509,8 @@ public class HtmlWidgets {
                 "  data-src=\"" + img2Url + 
                 "\" alt=\"data:image/png;base64\">",
 
-                "&nbsp;data:image/png;base64&nbsp;<a href=\"#\" onclick=\"javascript:if(navigator.clipboard==undefined){alert('copy to clipboardd not available');return false};navigator.clipboard.writeText('" + img2Url +"');\" style=\"cursor: pointer; cursor: hand;\" >["+ EDStatic.copytexttoclipboardAr[language] + "]</a> " +                
-                "&nbsp;<a href=\"#\" onclick=\"javascript:if(navigator.clipboard==undefined){alert('copy to clipboardd not available');return false};"+
+                "&nbsp;data:image/png;base64&nbsp;<a href=\"#\" onclick=\"javascript:if(navigator.clipboard==undefined){alert('" + EDStatic.copytoclipboardnotavailableAr[language] + "');return false};navigator.clipboard.writeText('" + img2Url +"');\" style=\"cursor: pointer; cursor: hand;\" >["+ EDStatic.copytexttoclipboardAr[language] + "]</a> " +                
+                "&nbsp;<a href=\"#\" onclick=\"javascript:if(navigator.clipboard==undefined){alert('" + EDStatic.copytoclipboardnotavailableAr[language] +"');return false};"+
                 " var img = new Image();"+
                 " img.onload = () => {"+
                 " const c = document.createElement('canvas');"+

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterHtmlTable.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterHtmlTable.java
@@ -370,6 +370,8 @@ public class TableWriterHtmlTable extends TableWriter {
                                 } else if (String2.isEmailAddress(s)) {                                    
                                     //to improve security, convert "@" to " at "
                                     s = XML.encodeAsHTMLAttribute(String2.replaceAll(s, "@", " at "));
+                                } else if (s.startsWith("data:image/png;base64,")) {                                    
+                                    url=s;                                    
                                 } else {
                                     s = encode(s);
                                 }
@@ -396,6 +398,11 @@ public class TableWriterHtmlTable extends TableWriter {
                                     } else if (iconAlt.equals("MOV")) { 
                                         viewer = HtmlWidgets.cssTooltipVideo(
                                             questionMarkImageUrl, "?", "", url);
+                                    } else if (iconAlt.equals("UNK") && url.startsWith("data:image/png;base64,")) { 
+                                        viewer = HtmlWidgets.cssTooltipImageBase64(
+                                            questionMarkImageUrl, "?", "",
+                                            url, "img" + (totalRows + row),language); 
+                                        s="";
                                     }
                                     if (viewer.length() > 0)
                                         s = viewer + "&nbsp;" + s;

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
@@ -1675,7 +1675,10 @@ public static boolean developmentMode = false;
 
         yourEmailAddressAr,
         zoomInAr,
-        zoomOutAr;
+        zoomOutAr,
+        
+        copytexttoclipboardAr,
+        copyimagetoclipboardAr;
 
     public static int[] imageWidths, imageHeights, pdfWidths, pdfHeights;
     private static String[] theLongDescriptionHtmlAr; //see the xxx() methods
@@ -3415,6 +3418,8 @@ wcsActive = false; //getSetupEVBoolean(setup, ev,          "wcsActive",         
         zoomInAr                     = getNotNothingString(messagesAr, "zoomIn",                     errorInMethod); 
         zoomOutAr                    = getNotNothingString(messagesAr, "zoomOut",                    errorInMethod); 
 
+        copytexttoclipboardAr        = getNotNothingString(messagesAr, "copytexttoclipboard",        errorInMethod); 
+        copyimagetoclipboardAr       = getNotNothingString(messagesAr, "copyimagetoclipboard",       errorInMethod); 
 
         for (int tl = 0; tl < nLanguages; tl++) {
             blacklistMsgAr[tl] = MessageFormat.format(blacklistMsgAr[tl], adminEmail);

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
@@ -1678,7 +1678,8 @@ public static boolean developmentMode = false;
         zoomOutAr,
         
         copytexttoclipboardAr,
-        copyimagetoclipboardAr;
+        copyimagetoclipboardAr,
+        copytoclipboardnotavailableAr;
 
     public static int[] imageWidths, imageHeights, pdfWidths, pdfHeights;
     private static String[] theLongDescriptionHtmlAr; //see the xxx() methods
@@ -3420,6 +3421,7 @@ wcsActive = false; //getSetupEVBoolean(setup, ev,          "wcsActive",         
 
         copytexttoclipboardAr        = getNotNothingString(messagesAr, "copytexttoclipboard",        errorInMethod); 
         copyimagetoclipboardAr       = getNotNothingString(messagesAr, "copyimagetoclipboard",       errorInMethod); 
+        copytoclipboardnotavailableAr= getNotNothingString(messagesAr, "copytoclipboardnotavailable",       errorInMethod); 
 
         for (int tl = 0; tl < nLanguages; tl++) {
             blacklistMsgAr[tl] = MessageFormat.format(blacklistMsgAr[tl], adminEmail);

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/messages.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/messages.xml
@@ -8670,6 +8670,7 @@ Many datasets can also be accessed via ERDDAP's Web Map Service (WMS).
 
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/messages.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/messages.xml
@@ -8668,4 +8668,8 @@ Many datasets can also be accessed via ERDDAP's Web Map Service (WMS).
 <zoomIn>Zoom In</zoomIn>
 <zoomOut>Zoom Out</zoomOut>
 
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-bn.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-bn.xml
@@ -6548,4 +6548,8 @@ ERDDAP এর ওয়েব ম্যাপ সার্ভিস (WMS ) এ�
 <yourEmailAddress>আপনার ইমেইল ঠিকানা</yourEmailAddress>
 <zoomIn>প্রসারিত করো</zoomIn>
 <zoomOut>ছোট করা</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-bn.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-bn.xml
@@ -6550,6 +6550,7 @@ ERDDAP এর ওয়েব ম্যাপ সার্ভিস (WMS ) এ�
 <zoomOut>ছোট করা</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-cs.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-cs.xml
@@ -7301,6 +7301,7 @@ K mnoha datovým sadám lze také přistupovat prostřednictvím webové mapové
 <zoomOut>Oddálit</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-cs.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-cs.xml
@@ -7299,4 +7299,8 @@ K mnoha datovým sadám lze také přistupovat prostřednictvím webové mapové
 <yourEmailAddress>Vaše emailová adresa</yourEmailAddress>
 <zoomIn>Přiblížit</zoomIn>
 <zoomOut>Oddálit</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-da.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-da.xml
@@ -7328,4 +7328,8 @@ Mange datasæt kan også tilgås via ERDDAP &#39;s Web Map Service (WMS ).
 <yourEmailAddress>Din email adresse</yourEmailAddress>
 <zoomIn>Zoom ind</zoomIn>
 <zoomOut>Zoome ud</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-da.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-da.xml
@@ -7330,6 +7330,7 @@ Mange datasæt kan også tilgås via ERDDAP &#39;s Web Map Service (WMS ).
 <zoomOut>Zoome ud</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-de.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-de.xml
@@ -7300,4 +7300,8 @@ Auf viele Datensätze kann auch über den Web Map Service (WMS ) von ERDDAP zuge
 <yourEmailAddress>Ihre E-Mail-Adresse</yourEmailAddress>
 <zoomIn>Hineinzoomen</zoomIn>
 <zoomOut>Rauszoomen</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-de.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-de.xml
@@ -7302,6 +7302,7 @@ Auf viele Datensätze kann auch über den Web Map Service (WMS ) von ERDDAP zuge
 <zoomOut>Rauszoomen</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-el.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-el.xml
@@ -7241,4 +7241,8 @@ You can access it at
 <yourEmailAddress>η ηλεκτρονική σου διεύθυνση</yourEmailAddress>
 <zoomIn>Μεγέθυνση</zoomIn>
 <zoomOut>Σμίκρυνση</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-el.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-el.xml
@@ -7243,6 +7243,7 @@ You can access it at
 <zoomOut>Σμίκρυνση</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-es.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-es.xml
@@ -7410,4 +7410,8 @@ También se puede acceder a muchos conjuntos de datos a través del Servicio de 
 <yourEmailAddress>Tu correo electrónico</yourEmailAddress>
 <zoomIn>Acercarse</zoomIn>
 <zoomOut>Disminuir el zoom</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-es.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-es.xml
@@ -7412,6 +7412,7 @@ También se puede acceder a muchos conjuntos de datos a través del Servicio de 
 <zoomOut>Disminuir el zoom</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-fi.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-fi.xml
@@ -7304,6 +7304,7 @@ Monet tietojoukot ovat käytettävissä myös ERDDAP :n Web Map Servicen (WMS ) 
 <zoomOut>Loitontaa</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-fi.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-fi.xml
@@ -7302,4 +7302,8 @@ Monet tietojoukot ovat käytettävissä myös ERDDAP :n Web Map Servicen (WMS ) 
 <yourEmailAddress>Sähköpostiosoitteesi</yourEmailAddress>
 <zoomIn>Lähennä</zoomIn>
 <zoomOut>Loitontaa</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-fr.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-fr.xml
@@ -7203,4 +7203,8 @@ De nombreux ensembles de données sont également accessibles via le Web Map Ser
 <yourEmailAddress>Votre adresse email</yourEmailAddress>
 <zoomIn>Agrandir</zoomIn>
 <zoomOut>Dézoomer</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-fr.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-fr.xml
@@ -7205,6 +7205,7 @@ De nombreux ensembles de données sont également accessibles via le Web Map Ser
 <zoomOut>Dézoomer</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ga.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ga.xml
@@ -7344,6 +7344,7 @@ Is féidir teacht ar go leor tacar sonraí trí Sheirbhís Léarscáileanna Gré
 <zoomOut>Zúmáil Amach</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ga.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ga.xml
@@ -7342,4 +7342,8 @@ Is féidir teacht ar go leor tacar sonraí trí Sheirbhís Léarscáileanna Gré
 <yourEmailAddress>Do sheoladh ríomhphoist</yourEmailAddress>
 <zoomIn>Zúmáil isteach</zoomIn>
 <zoomOut>Zúmáil Amach</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-gu.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-gu.xml
@@ -7313,4 +7313,8 @@ You can access it at
 <yourEmailAddress>તમારું ઇમેઇલ સરનામું</yourEmailAddress>
 <zoomIn>મોટું કરો</zoomIn>
 <zoomOut>ઝૂમ આઉટ</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-gu.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-gu.xml
@@ -7315,6 +7315,7 @@ You can access it at
 <zoomOut>ઝૂમ આઉટ</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-hi.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-hi.xml
@@ -6525,6 +6525,7 @@ You can access it at
 <zoomOut>ज़ूम आउट</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-hi.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-hi.xml
@@ -6523,4 +6523,8 @@ You can access it at
 <yourEmailAddress>आपका ईमेल पता</yourEmailAddress>
 <zoomIn>ज़ूम इन</zoomIn>
 <zoomOut>ज़ूम आउट</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-hu.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-hu.xml
@@ -7403,4 +7403,8 @@ Számos adatkészlet az ERDDAP szolgáltatásán (WMS ) keresztül is elérhető
 <yourEmailAddress>az email címed</yourEmailAddress>
 <zoomIn>Nagyítás</zoomIn>
 <zoomOut>Kicsinyítés</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-hu.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-hu.xml
@@ -7405,6 +7405,7 @@ Számos adatkészlet az ERDDAP szolgáltatásán (WMS ) keresztül is elérhető
 <zoomOut>Kicsinyítés</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-id.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-id.xml
@@ -7195,4 +7195,8 @@ Banyak dataset juga dapat diakses melalui Web Map Service (WMS ) ERDDAP .
 <yourEmailAddress>Alamat email anda</yourEmailAddress>
 <zoomIn>Perbesar</zoomIn>
 <zoomOut>Perkecil</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-id.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-id.xml
@@ -7197,6 +7197,7 @@ Banyak dataset juga dapat diakses melalui Web Map Service (WMS ) ERDDAP .
 <zoomOut>Perkecil</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-it.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-it.xml
@@ -7279,6 +7279,7 @@ You can access it at
 <zoomOut>Rimpicciolisci</zoomOut>
 
 <copytexttoclipboard>Copia il testo negli appunti</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy nella clipboard non disponibile</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copia l'immagine negli appunti</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-it.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-it.xml
@@ -7277,4 +7277,8 @@ You can access it at
 <yourEmailAddress>Il tuo indirizzo di posta elettronica</yourEmailAddress>
 <zoomIn>Ingrandire</zoomIn>
 <zoomOut>Rimpicciolisci</zoomOut>
+
+<copytexttoclipboard>Copia il testo negli appunti</copytexttoclipboard>
+<copyimagetoclipboard>Copia l'immagine negli appunti</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ja.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ja.xml
@@ -6247,6 +6247,7 @@ You can access it at
 <zoomOut>ズームアウトする</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ja.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ja.xml
@@ -6245,4 +6245,8 @@ You can access it at
 <yourEmailAddress>あなたのメールアドレス</yourEmailAddress>
 <zoomIn>ズームイン</zoomIn>
 <zoomOut>ズームアウトする</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ko.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ko.xml
@@ -7478,6 +7478,7 @@ You can access it at
 <zoomOut>축소</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ko.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ko.xml
@@ -7476,4 +7476,8 @@ You can access it at
 <yourEmailAddress>귀하의 이메일 주소</yourEmailAddress>
 <zoomIn>확대</zoomIn>
 <zoomOut>축소</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-mr.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-mr.xml
@@ -7359,6 +7359,7 @@ You can access it at
 <zoomOut>झूम कमी करा</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-mr.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-mr.xml
@@ -7357,4 +7357,8 @@ You can access it at
 <yourEmailAddress>तुमचा ईमेल पत्ता</yourEmailAddress>
 <zoomIn>प्रतिमेचे दृष्य रूप मोठे करा</zoomIn>
 <zoomOut>झूम कमी करा</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-nl.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-nl.xml
@@ -7292,4 +7292,8 @@ Veel datasets zijn ook toegankelijk via ERDDAP &#39;s Web Map Service (WMS ).
 <yourEmailAddress>jouw e-mailadres</yourEmailAddress>
 <zoomIn>In zoomen</zoomIn>
 <zoomOut>Uitzoomen</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-nl.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-nl.xml
@@ -7294,6 +7294,7 @@ Veel datasets zijn ook toegankelijk via ERDDAP &#39;s Web Map Service (WMS ).
 <zoomOut>Uitzoomen</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-no.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-no.xml
@@ -7267,6 +7267,7 @@ Mange datasett kan også nås via ERDDAP Web Map Service (WMS ).
 <zoomOut>Zoome ut</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-no.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-no.xml
@@ -7265,4 +7265,8 @@ Mange datasett kan også nås via ERDDAP Web Map Service (WMS ).
 <yourEmailAddress>Din epostadresse</yourEmailAddress>
 <zoomIn>Zoom inn</zoomIn>
 <zoomOut>Zoome ut</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-pa.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-pa.xml
@@ -6542,4 +6542,8 @@ You can access it at
 <yourEmailAddress>ਤੁਹਾਡਾ ਈਮੇਲ ਪਤਾ</yourEmailAddress>
 <zoomIn>ਵੱਡਾ ਕਰਨਾ</zoomIn>
 <zoomOut>ਜ਼ੂਮ ਆਉਟ ਕਰੋ</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-pa.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-pa.xml
@@ -6544,6 +6544,7 @@ You can access it at
 <zoomOut>ਜ਼ੂਮ ਆਉਟ ਕਰੋ</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-pl.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-pl.xml
@@ -7261,6 +7261,7 @@ Do wielu zbiorów danych można również uzyskać dostęp za pośrednictwem Web
 <zoomOut>Pomniejsz</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-pl.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-pl.xml
@@ -7259,4 +7259,8 @@ Do wielu zbiorów danych można również uzyskać dostęp za pośrednictwem Web
 <yourEmailAddress>Twój adres email</yourEmailAddress>
 <zoomIn>Zbliżenie</zoomIn>
 <zoomOut>Pomniejsz</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-pt.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-pt.xml
@@ -7291,6 +7291,7 @@ Muitos conjuntos de dados também podem ser acessados via Web Map Service (WMS )
 <zoomOut>Reduzir o zoom</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-pt.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-pt.xml
@@ -7289,4 +7289,8 @@ Muitos conjuntos de dados também podem ser acessados via Web Map Service (WMS )
 <yourEmailAddress>Seu endereço de email</yourEmailAddress>
 <zoomIn>Mais Zoom</zoomIn>
 <zoomOut>Reduzir o zoom</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ro.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ro.xml
@@ -7271,6 +7271,7 @@ Multe seturi de date pot fi accesate și prin serviciul de hărți web (WMS ) al
 <zoomOut>A micsora</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ro.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ro.xml
@@ -7269,4 +7269,8 @@ Multe seturi de date pot fi accesate și prin serviciul de hărți web (WMS ) al
 <yourEmailAddress>adresa ta de email</yourEmailAddress>
 <zoomIn>Mareste</zoomIn>
 <zoomOut>A micsora</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ru.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ru.xml
@@ -7404,6 +7404,7 @@ You can access it at
 <zoomOut>Уменьшить</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ru.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ru.xml
@@ -7402,4 +7402,8 @@ You can access it at
 <yourEmailAddress>Ваш адрес электронной почты</yourEmailAddress>
 <zoomIn>Увеличить</zoomIn>
 <zoomOut>Уменьшить</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-sv.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-sv.xml
@@ -7253,6 +7253,7 @@ Många datamängder kan också nås via ERDDAP :s Web Map Service (WMS ).
 <zoomOut>Zooma ut</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-sv.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-sv.xml
@@ -7251,4 +7251,8 @@ Många datamängder kan också nås via ERDDAP :s Web Map Service (WMS ).
 <yourEmailAddress>din e-postadress</yourEmailAddress>
 <zoomIn>Zooma in</zoomIn>
 <zoomOut>Zooma ut</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-sw.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-sw.xml
@@ -7243,4 +7243,8 @@ Seti nyingi za data pia zinaweza kufikiwa kupitia Huduma ya Ramani ya Wavuti ya 
 <yourEmailAddress>Barua pepe yako</yourEmailAddress>
 <zoomIn>Kuza</zoomIn>
 <zoomOut>Zoom Out</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-sw.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-sw.xml
@@ -7245,6 +7245,7 @@ Seti nyingi za data pia zinaweza kufikiwa kupitia Huduma ya Ramani ya Wavuti ya 
 <zoomOut>Zoom Out</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-th.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-th.xml
@@ -6488,4 +6488,8 @@ You can access it at
 <yourEmailAddress>ที่อยู่อีเมลของคุณ</yourEmailAddress>
 <zoomIn>ขยายเข้า</zoomIn>
 <zoomOut>ซูมออก</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-th.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-th.xml
@@ -6490,6 +6490,7 @@ You can access it at
 <zoomOut>ซูมออก</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-tl.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-tl.xml
@@ -7212,6 +7212,7 @@ Maraming mga dataset ang maaari ding ma-access sa pamamagitan ng Web Map Service
 <zoomOut>Mag-zoom Out</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-tl.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-tl.xml
@@ -7210,4 +7210,8 @@ Maraming mga dataset ang maaari ding ma-access sa pamamagitan ng Web Map Service
 <yourEmailAddress>ang iyong email address</yourEmailAddress>
 <zoomIn>Palakihin</zoomIn>
 <zoomOut>Mag-zoom Out</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-tr.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-tr.xml
@@ -7308,4 +7308,8 @@ ERDDAP Web Harita Hizmeti (WMS ) üzerinden de birçok veri setine erişilebilir
 <yourEmailAddress>e</yourEmailAddress>
 <zoomIn>Yakınlaştır</zoomIn>
 <zoomOut>Uzaklaştırmak</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-tr.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-tr.xml
@@ -7310,6 +7310,7 @@ ERDDAP Web Harita Hizmeti (WMS ) üzerinden de birçok veri setine erişilebilir
 <zoomOut>Uzaklaştırmak</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-uk.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-uk.xml
@@ -7228,4 +7228,8 @@ You can access it at
 <yourEmailAddress>Ваша електронна адреса</yourEmailAddress>
 <zoomIn>Збільшувати</zoomIn>
 <zoomOut>Зменшення</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-uk.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-uk.xml
@@ -7230,6 +7230,7 @@ You can access it at
 <zoomOut>Зменшення</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ur.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ur.xml
@@ -5729,4 +5729,8 @@ You can access it at
 <yourEmailAddress>آپ کا ای میل پتہ</yourEmailAddress>
 <zoomIn>زوم ان</zoomIn>
 <zoomOut>دور کرنا</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ur.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-ur.xml
@@ -5731,6 +5731,7 @@ You can access it at
 <zoomOut>دور کرنا</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-vi.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-vi.xml
@@ -7473,6 +7473,7 @@ Nhiều bộ dữ liệu cũng có thể được truy cập thông qua Dịch v
 <zoomOut>Thu nhỏ</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-vi.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-vi.xml
@@ -7471,4 +7471,8 @@ Nhiều bộ dữ liệu cũng có thể được truy cập thông qua Dịch v
 <yourEmailAddress>địa chỉ email của bạn</yourEmailAddress>
 <zoomIn>Phóng to</zoomIn>
 <zoomOut>Thu nhỏ</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-zh-TW.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-zh-TW.xml
@@ -6054,6 +6054,7 @@ You can access it at
 <zoomOut>縮小</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-zh-TW.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-zh-TW.xml
@@ -6052,4 +6052,8 @@ You can access it at
 <yourEmailAddress>您的電子郵件地址</yourEmailAddress>
 <zoomIn>放大</zoomIn>
 <zoomOut>縮小</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-zh-cn.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-zh-cn.xml
@@ -6055,6 +6055,7 @@ You can access it at
 <zoomOut>缩小</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-zh-cn.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messages-zh-cn.xml
@@ -6053,4 +6053,8 @@ You can access it at
 <yourEmailAddress>您的电子邮件地址</yourEmailAddress>
 <zoomIn>放大</zoomIn>
 <zoomOut>缩小</zoomOut>
+
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messagesOld.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messagesOld.xml
@@ -8627,4 +8627,7 @@ Many datasets can also be accessed via ERDDAP's Web Map Service (WMS).
 <zoomIn>Zoom In</zoomIn>
 <zoomOut>Zoom Out</zoomOut>
 
+<copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
+
 </erddapMessages>

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messagesOld.xml
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/translatedMessages/messagesOld.xml
@@ -8628,6 +8628,7 @@ Many datasets can also be accessed via ERDDAP's Web Map Service (WMS).
 <zoomOut>Zoom Out</zoomOut>
 
 <copytexttoclipboard>Copy text to clipboard</copytexttoclipboard>
+<copytoclipboardnotavailable>Copy to clipboard not available</copytoclipboardnotavailable>
 <copyimagetoclipboard>Copy image to clipboard</copyimagetoclipboard>
 
 </erddapMessages>


### PR DESCRIPTION
If a string field contains a base64 image (like "data:image/png;base64,iVBORw0KGgoAAAAN ....") the htmlTable view display a question mark icon and two button, "[copy image to clipboard]" and "[copy text to clipboard]"
The question mark icon display the image on mouse over
The "[copy image to clipboard]" create a copy of the image in the clipboard
The "[copy text to clipboard]" copy the base64 string in the clipboard.
Copy to clipboard is available only on https

The buttons text and the message shown when the cliboard functionality is not available are not translated but configured on each messages xml file in english