### PR TITLE
Sort ignore case avoiding casting

### DIFF
--- a/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
+++ b/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
@@ -2837,7 +2837,7 @@ public abstract class PrimitiveArray {
      *   second item in the sorted list, ...).
      */
     public int[] rank(boolean ascending) {
-        ArrayList table = new ArrayList();
+        ArrayList<PrimitiveArray> table = new ArrayList<>();
         table.add(this);
         return rank(table, new int[]{0}, new boolean[]{ascending});
     }
@@ -2861,22 +2861,22 @@ public abstract class PrimitiveArray {
      *   in the sorted list, rank[1] is the row number of the
      *   second item in the sorted list, ...).
      */
-    public static int[] rank(List table, int keys[], boolean[] ascending) {
+    public static int[] rank(List<PrimitiveArray> table, int keys[], boolean[] ascending) {
         return lowRank(new RowComparator(table, keys, ascending), table);
     }
 
     /** This is like rank, but StringArrays are tested case insensitively.   */
-    public static int[] rankIgnoreCase(List table, int keys[], boolean[] ascending) {
+    public static int[] rankIgnoreCase(List<PrimitiveArray> table, int keys[], boolean[] ascending) {
         return lowRank(new RowComparatorIgnoreCase(table, keys, ascending), table);
     }
     
-    private static int[] lowRank(RowComparator comparator, List table) {
+    private static int[] lowRank(RowComparator comparator, List<PrimitiveArray> table) {
 
         //create the rowArray with pointer to specific rows
-        int n = ((PrimitiveArray)table.get(0)).size();
+        int n = table.get(0).size();
         Integer rowArray[] = new Integer[n];
         for (int i = 0; i < n; i++)
-            rowArray[i] = new Integer(i);
+            rowArray[i] = i;
 
         //sort the rows
         Arrays.sort(rowArray, comparator);   //this is "stable"

--- a/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
+++ b/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
@@ -2874,7 +2874,7 @@ public abstract class PrimitiveArray {
 
         //create the rowArray with pointer to specific rows
         int n = table.get(0).size();
-        Integer rowArray[] = new Integer[n];
+        Integer[] rowArray = new Integer[n];
         for (int i = 0; i < n; i++)
             rowArray[i] = i;
 
@@ -2883,9 +2883,9 @@ public abstract class PrimitiveArray {
         //String2.log("rank results: " + String2.toCSSVString(integerArray));
 
         //create the int[] 
-        int newArray[] = new int[n];
+        int[] newArray = new int[n];
         for (int i = 0; i < n; i++)
-            newArray[i] = rowArray[i].intValue();
+            newArray[i] = rowArray[i];
 
         return newArray;
     }
@@ -2906,26 +2906,26 @@ public abstract class PrimitiveArray {
      *    indicating if the arrays are to be sorted by a given key in 
      *    ascending or descending order.
      */
-    public static void sort(List table, int keys[], boolean[] ascending) {
+    public static void sort(List<PrimitiveArray> table, int[] keys, boolean[] ascending) {
 
         //rank the rows
-        int ranks[] = rank(table, keys, ascending);
+        int[] ranks = rank(table, keys, ascending);
 
         //reorder the columns
         for (int col = 0; col < table.size(); col++) {
-            ((PrimitiveArray)table.get(col)).reorder(ranks);
+            table.get(col).reorder(ranks);
         }
     }
 
     /** This is like sort, but StringArrays are tested case insensitively.   */
-    public static void sortIgnoreCase(List table, int keys[], boolean[] ascending) {
+    public static void sortIgnoreCase(List<PrimitiveArray> table, int[] keys, boolean[] ascending) {
 
         //rank the rows
-        int ranks[] = rankIgnoreCase(table, keys, ascending);
+        int[] ranks = rankIgnoreCase(table, keys, ascending);
 
         //reorder the columns
         for (int col = 0; col < table.size(); col++) {
-            ((PrimitiveArray)table.get(col)).reorder(ranks);
+            table.get(col).reorder(ranks);
         }
     }
 
@@ -2941,7 +2941,7 @@ public abstract class PrimitiveArray {
     public static void copyRow(List<PrimitiveArray> table, int from, int to) {
         int nColumns = table.size();
         for (int col = 0; col < nColumns; col++) 
-            ((PrimitiveArray)table.get(col)).copy(from, to);
+            table.get(col).copy(from, to);
     }
 
     /**
@@ -3015,9 +3015,9 @@ public abstract class PrimitiveArray {
      * @param table a List of PrimitiveArray
      * @return the number of duplicates removed
      */
-    public static int removeDuplicates(List table) {
+    public static int removeDuplicates(List<PrimitiveArray> table) {
 
-        int nRows = ((PrimitiveArray)table.get(0)).size();
+        int nRows = table.get(0).size();
         if (nRows <= 1) 
             return 0;
         int nColumns = table.size();
@@ -3026,7 +3026,7 @@ public abstract class PrimitiveArray {
             //does it equal row above?
             boolean equal = true;
             for (int col = 0; col < nColumns; col++) {
-                if (((PrimitiveArray)table.get(col)).compare(row - 1, row) != 0) {
+                if (table.get(col).compare(row - 1, row) != 0) {
                     equal = false;
                     break;
                 }
@@ -3035,14 +3035,14 @@ public abstract class PrimitiveArray {
                 //no? copy row 'row' to row 'nUnique'
                 if (row != nUnique) 
                     for (int col = 0; col < nColumns; col++) 
-                        ((PrimitiveArray)table.get(col)).copy(row, nUnique);
+                        table.get(col).copy(row, nUnique);
                 nUnique++;
             }
         }
 
         //remove the stuff at the end
         for (int col = 0; col < nColumns; col++) 
-            ((PrimitiveArray)table.get(col)).removeRange(nUnique, nRows);
+            table.get(col).removeRange(nUnique, nRows);
 
         return nRows - nUnique;
     }

--- a/WEB-INF/classes/com/cohort/array/RowComparator.java
+++ b/WEB-INF/classes/com/cohort/array/RowComparator.java
@@ -14,9 +14,9 @@ import java.util.List;
  * This is used by PrimitiveArray.rank to rank a table of data stored as 
  * a PrimitiveArray[].
  */
-public class RowComparator implements Comparator {
+public class RowComparator implements Comparator<Integer> {
 
-    protected List table;
+    protected List<PrimitiveArray> table;
     protected int[] keys;
     protected boolean[] ascending;
 
@@ -32,7 +32,7 @@ public class RowComparator implements Comparator {
      *    ascending or descending order.
      * @throws RuntimeException if trouble
      */
-    public RowComparator(List table, int keys[], boolean[] ascending) {
+    public RowComparator(List<PrimitiveArray> table, int keys[], boolean[] ascending) {
         String errorInMethod = String2.ERROR + " in RowComparator constructor:\n";
         Test.ensureNotEqual(keys.length, 0, errorInMethod + "keys.length must not be 0.");
         Test.ensureEqual(keys.length, ascending.length, errorInMethod + "keys.length must equal ascending.length.");
@@ -54,10 +54,9 @@ public class RowComparator implements Comparator {
      *   the value at index2.  
      *   Think "o1 - o2".
      */
-    public int compare(Object o1, Object o2) {
+    public int compare(Integer o1, Integer o2) {
         for (int k = 0; k < keys.length; k++) {
-            int result = ((PrimitiveArray)table.get(keys[k])).compare(
-                ((Integer)o1).intValue(), ((Integer)o2).intValue());
+            int result = table.get(keys[k]).compare(o1, o2);
             if (result != 0) 
                 return ascending[k]? result : -result;
         }
@@ -92,4 +91,3 @@ public class RowComparator implements Comparator {
     }
 
 }
-

--- a/WEB-INF/classes/com/cohort/array/RowComparatorIgnoreCase.java
+++ b/WEB-INF/classes/com/cohort/array/RowComparatorIgnoreCase.java
@@ -6,6 +6,8 @@
 package com.cohort.array;
 
 import com.cohort.util.*;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -30,7 +32,7 @@ public class RowComparatorIgnoreCase extends RowComparator {
      *    ascending or descending order.
      * @throws RuntimeException if trouble
      */
-    public RowComparatorIgnoreCase(List table, int keys[], boolean[] ascending) {
+    public RowComparatorIgnoreCase(List<PrimitiveArray> table, int keys[], boolean[] ascending) {
         super(table, keys, ascending);
     }
 
@@ -44,10 +46,9 @@ public class RowComparatorIgnoreCase extends RowComparator {
      *   the value at index2.  
      *   Think "o1 - o2".
      */
-    public int compare(Object o1, Object o2) {
+    public int compare(Integer o1, Integer o2) {
         for (int k = 0; k < keys.length; k++) {
-            int result = ((PrimitiveArray)table.get(keys[k])).compareIgnoreCase(
-                ((Integer)o1).intValue(), ((Integer)o2).intValue());
+            int result = table.get(keys[k]).compareIgnoreCase(o1, o2);
             if (result != 0) 
                 return ascending[k]? result : -result;
         }
@@ -82,4 +83,3 @@ public class RowComparatorIgnoreCase extends RowComparator {
     }
 
 }
-

--- a/WEB-INF/classes/com/cohort/util/StringHolder.java
+++ b/WEB-INF/classes/com/cohort/util/StringHolder.java
@@ -107,7 +107,7 @@ public class StringHolder {
         if (o == null)
             return 1; //see StringComparatorIgnoreCase
         //see String compareTo documentation
-        char other[] = ((StringHolder)o).charArray();
+        char other[] = o.charArray();
         int thisSize = car.length;
         int otherSize = other.length;
         int min = Math.min(thisSize, otherSize);

--- a/WEB-INF/classes/com/cohort/util/StringHolderComparator.java
+++ b/WEB-INF/classes/com/cohort/util/StringHolderComparator.java
@@ -11,7 +11,7 @@ import java.util.Comparator;
  * This is used by StringArray to do a case-insensitive sort 
  * (better than String.CASE_INSENSITIVE_ORDER).
  */
-public class StringHolderComparator implements Comparator {
+public class StringHolderComparator implements Comparator<StringHolder> {
 
 
     /**
@@ -24,10 +24,10 @@ public class StringHolderComparator implements Comparator {
      *   the value at index2.  
      *   Think "o1 - o2".
      */
-    public int compare(Object o1, Object o2) {
+    public int compare(StringHolder o1, StringHolder o2) {
         if (o1 == null)
             return o2 == null? 0 : -1;
-        return ((StringHolder)o1).compareTo((StringHolder)o2);
+        return o1.compareTo(o2);
     }
 
     /**
@@ -40,4 +40,3 @@ public class StringHolderComparator implements Comparator {
     }
 
 }
-

--- a/WEB-INF/classes/com/cohort/util/StringHolderComparatorIgnoreCase.java
+++ b/WEB-INF/classes/com/cohort/util/StringHolderComparatorIgnoreCase.java
@@ -11,7 +11,7 @@ import java.util.Comparator;
  * This is used by StringArray to do a case-insensitive sort 
  * (better than String.CASE_INSENSITIVE_ORDER).
  */
-public class StringHolderComparatorIgnoreCase implements Comparator {
+public class StringHolderComparatorIgnoreCase implements Comparator<StringHolder> {
 
 
     /**
@@ -24,12 +24,12 @@ public class StringHolderComparatorIgnoreCase implements Comparator {
      *   the value at index2.  
      *   Think "o1 - o2".
      */
-    public int compare(Object o1, Object o2) {
+    public int compare(StringHolder o1, StringHolder o2) {
         if (o1 == null)
             return o2 == null? 0 : -1;
         if (o2 == null) 
             return 1;
-        return ((StringHolder)o1).compareToIgnoreCase((StringHolder)o2); //it is fancy
+        return o1.compareToIgnoreCase(o2); //it is fancy
     }
 
     /**


### PR DESCRIPTION
The improvements here are harder to capture in the tests and profiler. Without the changes the full EDDTableFromNcFiles.testNThreads() took 763,570 ms, with the changes it was 609,569 ms. These improvements would be due eliminating the overhead from casting (mostly cpu time, with a couple of these changes to reduce boxing there should be slightly less heap usage as well). My profiling last week explicitly had the improvements inside of sortIgnoreCase (not today, which is likely due to randomness in the sampler).