### PR TITLE
Optimize maxStringLength

### DIFF
--- a/WEB-INF/classes/com/cohort/array/StringArray.java
+++ b/WEB-INF/classes/com/cohort/array/StringArray.java
@@ -1800,8 +1800,9 @@ public class StringArray extends PrimitiveArray {
     public int maxStringLength() {
         int max = 0;
         for (int i = 0; i < size; i++) {
-            String s = get(i);
-            max = Math.max(max, s == null? 0 : s.length());
+            StringHolder sh = getStringHolder(i);
+            int length = (sh == null || sh.charArray() == null) ? 0 : sh.charArray().length;
+            max = Math.max(max, length);
         }
         return max;
     }


### PR DESCRIPTION
Because StringHolders store the strings as char array, using that directly instead of converting to a string saves a lot of time (and heap allocations).

Prior to this change Table.testReadInvalidCRA() ran in 117,394 ms with 72,509 ms being spent in StringArray.maxStringLength

With this change total time is 38,999 ms with StringArray.maxStringLength at 41.2 ms. There were also speed ups outside of maxStringLength which I believe is due to reducing GC.