### PR TITLE
Modified pom.xml to build ERDDAP WAR in place with mvn package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ images/gadgets
 images/post
 *.class
 Thumbs.db
+/content/
+/data/
+/target/
 .vscode
 .settings
 .classpath

--- a/pom.xml
+++ b/pom.xml
@@ -98,17 +98,10 @@ since this is impossible for AWS S3 dependencies without Maven.
     </repositories>
 
     <build>
+        <sourceDirectory>WEB-INF/classes</sourceDirectory>
         <resources>
             <resource>
-                <directory>src/main/java</directory>
-                <includes>
-                    <include>**/*.properties</include>
-                    <include>**/*.csv</include>
-                    <include>**/*.tsv</include>
-                    <include>**/*.txt</include>
-                    <include>**/*.cpt</include>
-                    <include>**/*.xml</include>
-                </includes>
+                <directory>WEB-INF/classes</directory>
             </resource>
         </resources>
         <plugins>
@@ -145,9 +138,7 @@ since this is impossible for AWS S3 dependencies without Maven.
                         <exclude>gov/noaa/pfel/erddap/dataset/EDDTableFromNWISDV.javaINACTIVE</exclude>
                         <exclude>gov/noaa/pfel/erddap/dataset/EDDTableFromPostDatabase.javaINACTIVE</exclude>
                         <exclude>gov/noaa/pfel/erddap/dataset/EDDTableFromPostNcFiles.javaINACTIVE</exclude>
-                        
                         <exclude>gov/noaa/pfel/coastwatch/util/FileVisitorDNLS.javaOLD</exclude>
-
                     </excludes>
                 </configuration>
             </plugin>
@@ -157,6 +148,10 @@ since this is impossible for AWS S3 dependencies without Maven.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <version>3.3.2</version>
+                <configuration>
+                    <warSourceDirectory>${project.basedir}</warSourceDirectory>
+                    <warSourceExcludes>WEB-INF/lib/**, target/**, data/**, content/**, .settings/**, *.*</warSourceExcludes>
+                </configuration>
             </plugin>
 
             <!-- NOT ACTIVE. See above and below.
@@ -422,9 +417,7 @@ since this is impossible for AWS S3 dependencies without Maven.
             <artifactId>netcdfAll</artifactId>
             <version>5.5.3</version>  <!-- version number duplicated several times below -->
             <scope>system</scope>
-            <!-- Bob uses fixed path... -->
-            <systemPath>C:/programs/mavenERDDAP/ERDDAP/repo/edu/ucar/netcdfAll/5.5.3/netcdfAll-5.5.3.jar</systemPath> <!-- gets WARNING about absolute path, but okay -->
-            <!-- Chris uses <systemPath>${basedir}/netcdfAll-5.5.3.jar</systemPath> -->
+            <systemPath>${project.basedir}/WEB-INF/lib/netcdfAll-5.5.3.jar</systemPath>
         </dependency>
 
         <!-- These will be needed if I ever switch away from netcdfAll.


### PR DESCRIPTION
@ChrisPJohn These small pom.xml changes allow a version of the ERDDAP war file to be compiled via Maven in the `target` subdirectory by running:

```
mvn package
```

Or, step-by-step by running:

```
mvn resources:resources
mvn compile
mvn package
```

The resulting `target/ERDDAP-2.23-SNAPSHOT.war` file does not exactly match what is produced by [makeErddapWar.bat](https://github.com/BobSimons/erddap/blob/master/makeErddapWar.bat), but it's close enough for development purposes AFAICT.

Also, I wasn't sure how to handle the [netcdfAll-5.5.3.jar file issue in pom.xml](https://github.com/BobSimons/erddap/blob/master/pom.xml#L425-L427), but the simplest solution is to just reference it in place via relative path under `WEB-INF/lib` and not retain in pom.xml absolute paths that are specific to a local environment.  I can submit another PR with a different approach to resolve this that uses a Maven `settings.xml` file and also eliminates the absolute path in pom.xml.